### PR TITLE
Add lms_lineitems_endpoint column 

### DIFF
--- a/nbgrader/alembic/versions/2f06e9462d32_add_lms_lineitems_endpoint_column_to_.py
+++ b/nbgrader/alembic/versions/2f06e9462d32_add_lms_lineitems_endpoint_column_to_.py
@@ -1,0 +1,24 @@
+"""Add lms_lineitems_endpoint' column to course
+
+Revision ID: 2f06e9462d32
+Revises: e43177bfe90b
+Create Date: 2020-07-31 16:11:22.134115
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2f06e9462d32'
+down_revision = 'e43177bfe90b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('course', sa.Column('lms_lineitems_endpoint', sa.String(128), nullable=True))
+
+
+def downgrade():
+    op.drop_column('course', 'lms_lineitems_endpoint')


### PR DESCRIPTION
For grades submission in LTI 1.3 the request is made to specific Line Item (in lms) so to get this url the logic in our Illumidesk repo register the value of  `https://purl.imsglobal.org/spec/lti-ags/claim/endpoint` in this new column  `lms_lineitems_endpoint` that is used to obtain a list of line items in the current course. One item in that list should match with the assignment name in nbgrader.